### PR TITLE
chore: add dev Docker tag for main branch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   docker:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.ref_type == 'tag'
+    if: github.event_name == 'pull_request' || github.ref_type == 'tag' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:
       packages: write
 
@@ -87,6 +87,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=raw,value=dev,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
This PR enables continuous Docker image builds for the main branch with a `dev` tag.

## Changes

- **docker job condition**: Updated to run on main branch pushes in addition to PRs and tags
- **metadata tags**: Added `type=raw,value=dev,enable={{is_default_branch}}` to create a `dev` tag

## Behavior

After merging, every push to `main` will:
1. Run all tests
2. Build and push Docker image to `ghcr.io/meerumschlungen/sharriff:dev`
3. Update the `dev` tag to always point to the latest main commit

## Benefits

- Enables testing of unreleased features from main branch
- Provides a stable "bleeding edge" image for development environments
- No impact on version-tagged releases (still use semver tags)
- `dev` tag always reflects the current state of main