### PR TITLE
fix: Use qualified field names for *arr API sort parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,5 @@ coverage/
 *.temp
 .cache/
 
-config.dev.yaml
-config.test.yaml
-config.test.yaml, config.minimal.yaml, config.invalid.yaml
-config.test-orchestration.yaml
-test-api-sort.sh
+config.*.yaml
+!config.example.yaml

--- a/src/clients/ArrClient.ts
+++ b/src/clients/ArrClient.ts
@@ -38,10 +38,15 @@ interface ClientMetadata {
   idField: string;
   mediaSingular: string;
   mediaPlural: string;
+  sortTablePrefix: string;
 }
 
 /**
  * Registry of client-specific metadata
+ * NOTE: sortTablePrefix specifies the entity type returned by wanted/missing:
+ * - Radarr/Whisparr: movies (movie entities)
+ * - Sonarr: episodes (episode entities, NOT series)
+ * - Lidarr: albums (album entities, NOT artists)
  */
 const CLIENT_METADATA: Record<ArrType, ClientMetadata> = {
   radarr: {
@@ -50,6 +55,7 @@ const CLIENT_METADATA: Record<ArrType, ClientMetadata> = {
     idField: 'movieIds',
     mediaSingular: 'movie',
     mediaPlural: 'movies',
+    sortTablePrefix: 'movies',
   },
   sonarr: {
     apiVersion: 'v3',
@@ -57,6 +63,7 @@ const CLIENT_METADATA: Record<ArrType, ClientMetadata> = {
     idField: 'episodeIds',
     mediaSingular: 'episode',
     mediaPlural: 'episodes',
+    sortTablePrefix: 'episodes',
   },
   lidarr: {
     apiVersion: 'v1',
@@ -64,6 +71,7 @@ const CLIENT_METADATA: Record<ArrType, ClientMetadata> = {
     idField: 'albumIds',
     mediaSingular: 'album',
     mediaPlural: 'albums',
+    sortTablePrefix: 'albums',
   },
   whisparr: {
     apiVersion: 'v3',
@@ -71,13 +79,14 @@ const CLIENT_METADATA: Record<ArrType, ClientMetadata> = {
     idField: 'movieIds',
     mediaSingular: 'movie',
     mediaPlural: 'movies',
+    sortTablePrefix: 'movies',
   },
 };
 
 /**
- * Sort key mapping for search orders
+ * Base sort field names (without table prefix)
  */
-const SORT_KEY_MAP: Record<string, string> = {
+const BASE_SORT_FIELDS: Record<string, string> = {
   last_searched: 'lastSearchTime',
   last_added: 'dateAdded',
   release_date: 'releaseDate',
@@ -144,8 +153,13 @@ export class ArrClient {
       this.settings.search_order === 'random' ? DEFAULT_SEARCH_ORDER : this.settings.search_order;
     const lastUnderscore = order.lastIndexOf('_');
     const prefix = order.slice(0, lastUnderscore);
+
+    // Build qualified sort key: "movies.lastSearchTime", "episodes.lastSearchTime", etc.
+    const baseField = BASE_SORT_FIELDS[prefix] ?? 'title';
+    const sortKey = `${this.metadata.sortTablePrefix}.${baseField}`;
+
     return {
-      sortKey: SORT_KEY_MAP[prefix] ?? 'title',
+      sortKey,
       sortDirection: order.slice(lastUnderscore + 1),
     };
   }

--- a/tests/arr-client.test.ts
+++ b/tests/arr-client.test.ts
@@ -45,6 +45,7 @@ describe('ArrClient metadata configuration', () => {
         idField: 'movieIds',
         mediaSingular: 'movie',
         mediaPlural: 'movies',
+        sortTablePrefix: 'movies',
       },
     ],
     [
@@ -55,6 +56,7 @@ describe('ArrClient metadata configuration', () => {
         idField: 'episodeIds',
         mediaSingular: 'episode',
         mediaPlural: 'episodes',
+        sortTablePrefix: 'episodes',
       },
     ],
     [
@@ -65,6 +67,7 @@ describe('ArrClient metadata configuration', () => {
         idField: 'albumIds',
         mediaSingular: 'album',
         mediaPlural: 'albums',
+        sortTablePrefix: 'albums',
       },
     ],
     [
@@ -75,6 +78,7 @@ describe('ArrClient metadata configuration', () => {
         idField: 'movieIds',
         mediaSingular: 'movie',
         mediaPlural: 'movies',
+        sortTablePrefix: 'movies',
       },
     ],
   ] as const)('%s client', (type, expectedMetadata) => {
@@ -194,7 +198,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'lastSearchTime',
+        sortKey: 'movies.lastSearchTime',
         sortDirection: 'ascending',
       });
     });
@@ -206,7 +210,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'lastSearchTime',
+        sortKey: 'movies.lastSearchTime',
         sortDirection: 'descending',
       });
     });
@@ -220,7 +224,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'dateAdded',
+        sortKey: 'movies.dateAdded',
         sortDirection: 'ascending',
       });
     });
@@ -232,7 +236,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'dateAdded',
+        sortKey: 'movies.dateAdded',
         sortDirection: 'descending',
       });
     });
@@ -246,7 +250,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'releaseDate',
+        sortKey: 'movies.releaseDate',
         sortDirection: 'ascending',
       });
     });
@@ -258,7 +262,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'releaseDate',
+        sortKey: 'movies.releaseDate',
         sortDirection: 'descending',
       });
     });
@@ -272,7 +276,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'title',
+        sortKey: 'movies.title',
         sortDirection: 'ascending',
       });
     });
@@ -284,7 +288,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'title',
+        sortKey: 'movies.title',
         sortDirection: 'descending',
       });
     });
@@ -298,7 +302,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'lastSearchTime',
+        sortKey: 'movies.lastSearchTime',
         sortDirection: 'ascending',
       });
     });
@@ -314,7 +318,7 @@ describe('ArrClient getSortParams', () => {
       const params = (client as any).getSortParams();
 
       expect(params).toEqual({
-        sortKey: 'title',
+        sortKey: 'movies.title',
         sortDirection: 'ascending',
       });
     });
@@ -450,7 +454,7 @@ describe('ArrClient integration methods', () => {
 
       expect(result).toEqual(mockResponse);
       expect(mockHttpGet).toHaveBeenCalledWith('/api/v3/wanted/missing', {
-        sortKey: 'lastSearchTime',
+        sortKey: 'movies.lastSearchTime',
         sortDirection: 'ascending',
         page: 1,
       });
@@ -467,7 +471,7 @@ describe('ArrClient integration methods', () => {
 
       expect(result).toEqual(mockResponse);
       expect(mockHttpGet).toHaveBeenCalledWith('/api/v3/wanted/cutoff', {
-        sortKey: 'lastSearchTime',
+        sortKey: 'movies.lastSearchTime',
         sortDirection: 'ascending',
       });
     });


### PR DESCRIPTION
## Problem

The *arr APIs (Radarr, Sonarr, Lidarr, Whisparr) were ignoring sort parameters in wanted/missing endpoint requests, causing items to be sorted by title regardless of the configured `search_order`. This led to the same items being searched repeatedly across cycles, particularly noticeable in Whisparr.

## Root Cause

The APIs require **qualified field names** in the format `table.field` for the `sortKey` parameter. We were previously sending unqualified field names like `lastSearchTime`, which the API would ignore and fall back to default sorting.

## Solution

1. **Added `sortTablePrefix` to `CLIENT_METADATA`** - Each arr type now defines its table prefix:
   - Radarr/Whisparr: `movies` (wanted/missing returns movie entities)
   - Sonarr: `episodes` (returns episode entities, NOT series)
   - Lidarr: `albums` (returns album entities, NOT artists)

2. **Updated `getSortParams()`** - Now builds qualified sort keys:
   - `movies.lastSearchTime`
   - `episodes.lastSearchTime`
   - `albums.lastSearchTime`

3. **Consolidated configuration** - Removed separate `SORT_TABLE_PREFIX` constant, everything now in `CLIENT_METADATA`

4. **Updated tests** - All test expectations now use qualified field names

## Verification

✅ Tested all 6 sort orders against production instances:
- `last_searched_ascending` - oldest searches first
- `last_searched_descending` - newest searches first  
- `last_added_ascending` - oldest additions first
- `last_added_descending` - newest additions first
- `alphabetical_ascending` - A-Z
- `alphabetical_descending` - Z-A

Each sort order produces distinct item lists, confirming the APIs are correctly processing the qualified sort keys.

## Changes

- `src/clients/ArrClient.ts`: Added `sortTablePrefix` to metadata, updated sort key generation
- `tests/arr-client.test.ts`: Updated test expectations for qualified field names
- `.gitignore`: Simplified config file pattern

## Testing

```bash
npm test  # All 169 tests pass
npm run check  # Type checking, linting, formatting all pass
```

Closes issue related to sort order not being respected.