### PR TITLE
refactor: Improve logging during media fetching

### DIFF
--- a/src/clients/ArrClient.ts
+++ b/src/clients/ArrClient.ts
@@ -271,14 +271,18 @@ export class ArrClient {
    * Fetch items and trigger indexer searches (missing or cutoff)
    * Returns the number of searches triggered
    */
-  private async processBatch(batchType: 'missing' | 'cutoff', limit?: number): Promise<number> {
+  private async processBatch(
+    batchType: 'missing' | 'cutoff',
+    limit?: number,
+    cycleId?: string
+  ): Promise<number> {
     const batchSizeSetting =
       batchType === 'missing' ? this.settings.missing_batch_size : this.settings.upgrade_batch_size;
     const batchSize = limit ?? batchSizeSetting;
 
     // -1 = unlimited, 0 = disabled
     if (batchSize === 0) {
-      this.logger.debug(`${batchType} triggers disabled (batch size = 0)`);
+      this.logger.debug({ cycleId }, `${batchType} triggers disabled (batch size = 0)`);
       return 0;
     }
 
@@ -290,7 +294,7 @@ export class ArrClient {
         batchType === 'cutoff'
           ? `No cutoff unmet ${this.metadata.mediaPlural} found`
           : `No missing ${this.metadata.mediaPlural} found`;
-      this.logger.info(message);
+      this.logger.info({ cycleId }, message);
       return 0;
     }
 
@@ -298,7 +302,7 @@ export class ArrClient {
       batchSize > 0 ? wantedItems.records.slice(0, batchSize) : wantedItems.records;
 
     this.logger.info(
-      { count: itemsToTrigger.length, type: batchType },
+      { count: itemsToTrigger.length, type: batchType, cycleId },
       `Fetched ${itemsToTrigger.length} wanted ${this.metadata.mediaPlural}`
     );
 
@@ -308,14 +312,14 @@ export class ArrClient {
         ? `Triggering searches for: ${titleSample}`
         : `Triggering searches for: ${titleSample}`;
 
-    this.logger.info({ count: itemsToTrigger.length, type: batchType }, logMessage);
+    this.logger.info({ count: itemsToTrigger.length, type: batchType, cycleId }, logMessage);
 
     const triggerStart = Date.now();
     await this.triggerSearchesWithStagger(itemsToTrigger);
     const triggerDuration = Date.now() - triggerStart;
 
     this.logger.info(
-      { count: itemsToTrigger.length, type: batchType, durationMs: triggerDuration },
+      { count: itemsToTrigger.length, type: batchType, durationMs: triggerDuration, cycleId },
       `Triggered ${itemsToTrigger.length} searches`
     );
 
@@ -326,15 +330,15 @@ export class ArrClient {
    * Trigger indexer searches for missing items
    * Returns the number of searches triggered
    */
-  async triggerMissingSearches(limit?: number): Promise<number> {
-    return this.processBatch('missing', limit);
+  async triggerMissingSearches(limit?: number, cycleId?: string): Promise<number> {
+    return this.processBatch('missing', limit, cycleId);
   }
 
   /**
    * Trigger indexer searches for cutoff unmet items (items that haven't reached quality cutoff)
    * Returns the number of searches triggered
    */
-  async triggerCutoffSearches(limit?: number): Promise<number> {
-    return this.processBatch('cutoff', limit);
+  async triggerCutoffSearches(limit?: number, cycleId?: string): Promise<number> {
+    return this.processBatch('cutoff', limit, cycleId);
   }
 }

--- a/src/clients/ArrClient.ts
+++ b/src/clients/ArrClient.ts
@@ -92,7 +92,20 @@ const BASE_SORT_FIELDS: Record<string, string> = {
   release_date: 'releaseDate',
   alphabetical: 'title',
 };
+/**
+ * Format a sample of titles for logging (first maxTitles items)
+ */
+function formatTitleSample(items: MediaItem[], maxTitles = 5): string {
+  const titles = items
+    .slice(0, maxTitles)
+    .map((item) => item.title ?? `ID:${item.id}`)
+    .join(', ');
 
+  if (items.length > maxTitles) {
+    return `${titles} ... and ${items.length - maxTitles} more`;
+  }
+  return titles;
+}
 export class ArrClient {
   readonly name: string;
   readonly weight: number;
@@ -256,8 +269,9 @@ export class ArrClient {
 
   /**
    * Fetch items and trigger indexer searches (missing or cutoff)
+   * Returns the number of searches triggered
    */
-  private async processBatch(batchType: 'missing' | 'cutoff', limit?: number): Promise<void> {
+  private async processBatch(batchType: 'missing' | 'cutoff', limit?: number): Promise<number> {
     const batchSizeSetting =
       batchType === 'missing' ? this.settings.missing_batch_size : this.settings.upgrade_batch_size;
     const batchSize = limit ?? batchSizeSetting;
@@ -265,7 +279,7 @@ export class ArrClient {
     // -1 = unlimited, 0 = disabled
     if (batchSize === 0) {
       this.logger.debug(`${batchType} triggers disabled (batch size = 0)`);
-      return;
+      return 0;
     }
 
     const params = batchSize > 0 ? { pageSize: batchSize } : undefined;
@@ -277,38 +291,50 @@ export class ArrClient {
           ? `No cutoff unmet ${this.metadata.mediaPlural} found`
           : `No missing ${this.metadata.mediaPlural} found`;
       this.logger.info(message);
-      return;
+      return 0;
     }
 
     const itemsToTrigger =
       batchSize > 0 ? wantedItems.records.slice(0, batchSize) : wantedItems.records;
 
+    this.logger.info(
+      { count: itemsToTrigger.length, type: batchType },
+      `Fetched ${itemsToTrigger.length} wanted ${this.metadata.mediaPlural}`
+    );
+
+    const titleSample = formatTitleSample(itemsToTrigger, 5);
     const logMessage =
       batchType === 'cutoff'
-        ? `Triggering indexer searches for ${itemsToTrigger.length} cutoff unmet ${this.metadata.mediaPlural}`
-        : `Triggering indexer searches for ${itemsToTrigger.length} missing ${this.metadata.mediaPlural}`;
+        ? `Triggering searches for: ${titleSample}`
+        : `Triggering searches for: ${titleSample}`;
 
     this.logger.info({ count: itemsToTrigger.length, type: batchType }, logMessage);
 
+    const triggerStart = Date.now();
     await this.triggerSearchesWithStagger(itemsToTrigger);
+    const triggerDuration = Date.now() - triggerStart;
 
     this.logger.info(
-      { count: itemsToTrigger.length, type: batchType },
-      `Completed triggering ${itemsToTrigger.length} indexer searches`
+      { count: itemsToTrigger.length, type: batchType, durationMs: triggerDuration },
+      `Triggered ${itemsToTrigger.length} searches`
     );
+
+    return itemsToTrigger.length;
   }
 
   /**
    * Trigger indexer searches for missing items
+   * Returns the number of searches triggered
    */
-  async triggerMissingSearches(limit?: number): Promise<void> {
+  async triggerMissingSearches(limit?: number): Promise<number> {
     return this.processBatch('missing', limit);
   }
 
   /**
    * Trigger indexer searches for cutoff unmet items (items that haven't reached quality cutoff)
+   * Returns the number of searches triggered
    */
-  async triggerCutoffSearches(limit?: number): Promise<void> {
+  async triggerCutoffSearches(limit?: number): Promise<number> {
     return this.processBatch('cutoff', limit);
   }
 }

--- a/src/clients/ArrClient.ts
+++ b/src/clients/ArrClient.ts
@@ -198,10 +198,11 @@ export class ArrClient {
    */
   async sendCommand(
     commandName: string,
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
+    cycleId?: string
   ): Promise<CommandResponse> {
     if (this.settings.dry_run) {
-      this.logger.info({ command: commandName, params }, 'DRY RUN - Would send command');
+      this.logger.info({ command: commandName, params, cycleId }, 'DRY RUN - Would send command');
       return { id: -1, name: commandName, state: 'dry-run' };
     }
 
@@ -228,12 +229,16 @@ export class ArrClient {
   /**
    * Trigger indexer search for a single item (mutex-protected atomic operation)
    */
-  protected async triggerItemSearch(item: MediaItem): Promise<void> {
+  protected async triggerItemSearch(item: MediaItem, cycleId?: string): Promise<void> {
     const release = await this.workMutex?.acquire();
     try {
-      await this.sendCommand(this.metadata.commandName, {
-        [this.metadata.idField]: [item.id],
-      });
+      await this.sendCommand(
+        this.metadata.commandName,
+        {
+          [this.metadata.idField]: [item.id],
+        },
+        cycleId
+      );
     } finally {
       release?.();
     }
@@ -242,7 +247,7 @@ export class ArrClient {
   /**
    * Trigger indexer searches with stagger delays between items
    */
-  protected async triggerSearchesWithStagger(items: MediaItem[]): Promise<void> {
+  protected async triggerSearchesWithStagger(items: MediaItem[], cycleId?: string): Promise<void> {
     const staggerSeconds = this.settings.stagger_interval_seconds;
 
     for (let i = 0; i < items.length; i++) {
@@ -254,11 +259,12 @@ export class ArrClient {
           progress: `${i + 1}/${items.length}`,
           itemId: item.id,
           title: item.title,
+          cycleId,
         },
         'Triggering indexer search for item'
       );
 
-      await this.triggerItemSearch(item);
+      await this.triggerItemSearch(item, cycleId);
 
       // Interruptible stagger delay
       if (staggerSeconds > 0 && i < items.length - 1 && this.shutdownEmitter) {
@@ -315,7 +321,7 @@ export class ArrClient {
     this.logger.info({ count: itemsToTrigger.length, type: batchType, cycleId }, logMessage);
 
     const triggerStart = Date.now();
-    await this.triggerSearchesWithStagger(itemsToTrigger);
+    await this.triggerSearchesWithStagger(itemsToTrigger, cycleId);
     const triggerDuration = Date.now() - triggerStart;
 
     this.logger.info(

--- a/src/orchestrator/Orchestrator.ts
+++ b/src/orchestrator/Orchestrator.ts
@@ -8,6 +8,7 @@ import { logger } from '../logger.js';
 import { interruptibleSleep } from '../utils/shutdown.js';
 import { EventEmitter } from 'events';
 import { Mutex } from '../utils/mutex.js';
+import { randomUUID } from 'crypto';
 
 const GRACEFUL_SHUTDOWN_TIMEOUT = 30000; // 30 seconds - max wait for in-flight operations
 
@@ -92,7 +93,12 @@ export class Orchestrator {
    * Run a single search cycle across all clients
    */
   private async runCycle(): Promise<void> {
-    logger.info('Starting indexer trigger cycle');
+    const cycleId = randomUUID();
+    const cycleStart = Date.now();
+    let totalTriggered = 0;
+    const instanceStats: { instance: string; missing: number; cutoff: number }[] = [];
+
+    logger.info({ cycleId }, 'Starting indexer trigger cycle');
 
     const totalWeight = this.clients.reduce((sum, client) => sum + client.weight, 0);
 
@@ -132,7 +138,7 @@ export class Orchestrator {
           'Processing instance'
         );
 
-        await client.triggerMissingSearches(clientBatchSize);
+        const missingCount = await client.triggerMissingSearches(clientBatchSize);
 
         // Also trigger searches for cutoff unmet items
         if (cutoffBatchSize === 0) {
@@ -152,7 +158,10 @@ export class Orchestrator {
           },
           'Processing cutoff unmet items'
         );
-        await client.triggerCutoffSearches(cutoffBatchSize);
+        const cutoffCount = await client.triggerCutoffSearches(cutoffBatchSize);
+
+        instanceStats.push({ instance: client.name, missing: missingCount, cutoff: cutoffCount });
+        totalTriggered += missingCount + cutoffCount;
       } catch (error) {
         logger.error(
           {
@@ -164,6 +173,17 @@ export class Orchestrator {
         );
       }
     }
+
+    const cycleDuration = Date.now() - cycleStart;
+    logger.info(
+      {
+        cycleId,
+        totalTriggered,
+        durationMs: cycleDuration,
+        instances: instanceStats,
+      },
+      'Cycle complete'
+    );
   }
 
   /**

--- a/src/orchestrator/Orchestrator.ts
+++ b/src/orchestrator/Orchestrator.ts
@@ -104,7 +104,7 @@ export class Orchestrator {
 
     for (const client of this.clients) {
       if (this.shouldStop) {
-        logger.warn({ instance: client.name }, 'Skipping due to shutdown request');
+        logger.warn({ instance: client.name, cycleId }, 'Skipping due to shutdown request');
         continue;
       }
 
@@ -120,7 +120,10 @@ export class Orchestrator {
         );
 
         if (clientBatchSize === 0) {
-          logger.debug({ instance: client.name }, 'Missing triggers disabled (batch size = 0)');
+          logger.debug(
+            { instance: client.name, cycleId },
+            'Missing triggers disabled (batch size = 0)'
+          );
           continue;
         }
 
@@ -134,15 +137,19 @@ export class Orchestrator {
                 : clientBatchSize === -1
                   ? 'Unlimited'
                   : clientBatchSize,
+            cycleId,
           },
           'Processing instance'
         );
 
-        const missingCount = await client.triggerMissingSearches(clientBatchSize);
+        const missingCount = await client.triggerMissingSearches(clientBatchSize, cycleId);
 
         // Also trigger searches for cutoff unmet items
         if (cutoffBatchSize === 0) {
-          logger.debug({ instance: client.name }, 'Cutoff triggers disabled (batch size = 0)');
+          logger.debug(
+            { instance: client.name, cycleId },
+            'Cutoff triggers disabled (batch size = 0)'
+          );
           continue;
         }
 
@@ -155,10 +162,11 @@ export class Orchestrator {
                 : cutoffBatchSize === -1
                   ? 'Unlimited'
                   : cutoffBatchSize,
+            cycleId,
           },
           'Processing cutoff unmet items'
         );
-        const cutoffCount = await client.triggerCutoffSearches(cutoffBatchSize);
+        const cutoffCount = await client.triggerCutoffSearches(cutoffBatchSize, cycleId);
 
         instanceStats.push({ instance: client.name, missing: missingCount, cutoff: cutoffCount });
         totalTriggered += missingCount + cutoffCount;
@@ -168,6 +176,7 @@ export class Orchestrator {
             instance: client.name,
             error: error instanceof Error ? error.message : String(error),
             stack: error instanceof Error ? error.stack : undefined,
+            cycleId,
           },
           'Error during indexer triggers, continuing to next instance'
         );

--- a/src/orchestrator/Orchestrator.ts
+++ b/src/orchestrator/Orchestrator.ts
@@ -145,28 +145,28 @@ export class Orchestrator {
         const missingCount = await client.triggerMissingSearches(clientBatchSize, cycleId);
 
         // Also trigger searches for cutoff unmet items
+        let cutoffCount = 0;
         if (cutoffBatchSize === 0) {
           logger.debug(
             { instance: client.name, cycleId },
             'Cutoff triggers disabled (batch size = 0)'
           );
-          continue;
+        } else {
+          logger.info(
+            {
+              instance: client.name,
+              cutoffBatch:
+                cutoffBatchSize === 0
+                  ? 'Disabled'
+                  : cutoffBatchSize === -1
+                    ? 'Unlimited'
+                    : cutoffBatchSize,
+              cycleId,
+            },
+            'Processing cutoff unmet items'
+          );
+          cutoffCount = await client.triggerCutoffSearches(cutoffBatchSize, cycleId);
         }
-
-        logger.info(
-          {
-            instance: client.name,
-            cutoffBatch:
-              cutoffBatchSize === 0
-                ? 'Disabled'
-                : cutoffBatchSize === -1
-                  ? 'Unlimited'
-                  : cutoffBatchSize,
-            cycleId,
-          },
-          'Processing cutoff unmet items'
-        );
-        const cutoffCount = await client.triggerCutoffSearches(cutoffBatchSize, cycleId);
 
         instanceStats.push({ instance: client.name, missing: missingCount, cutoff: cutoffCount });
         totalTriggered += missingCount + cutoffCount;

--- a/tests/arr-client.test.ts
+++ b/tests/arr-client.test.ts
@@ -130,7 +130,10 @@ describe('ArrClient metadata configuration', () => {
       await client.triggerMissingSearches(2);
 
       expect((client as any).fetchWantedItems).toHaveBeenCalledWith('missing', { pageSize: 2 });
-      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(mockRecords, undefined);
+      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(
+        mockRecords,
+        undefined
+      );
     });
 
     it('should handle cutoff items with batch limit', async () => {
@@ -141,7 +144,10 @@ describe('ArrClient metadata configuration', () => {
       await client.triggerCutoffSearches(1);
 
       expect((client as any).fetchWantedItems).toHaveBeenCalledWith('cutoff', { pageSize: 1 });
-      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(mockRecords, undefined);
+      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(
+        mockRecords,
+        undefined
+      );
     });
 
     it('should handle no missing items found', async () => {
@@ -184,7 +190,10 @@ describe('ArrClient metadata configuration', () => {
       await client.triggerMissingSearches(-1);
 
       expect((client as any).fetchWantedItems).toHaveBeenCalledWith('missing', undefined);
-      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(mockRecords, undefined);
+      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(
+        mockRecords,
+        undefined
+      );
     });
   });
 });

--- a/tests/arr-client.test.ts
+++ b/tests/arr-client.test.ts
@@ -130,7 +130,7 @@ describe('ArrClient metadata configuration', () => {
       await client.triggerMissingSearches(2);
 
       expect((client as any).fetchWantedItems).toHaveBeenCalledWith('missing', { pageSize: 2 });
-      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(mockRecords);
+      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(mockRecords, undefined);
     });
 
     it('should handle cutoff items with batch limit', async () => {
@@ -141,7 +141,7 @@ describe('ArrClient metadata configuration', () => {
       await client.triggerCutoffSearches(1);
 
       expect((client as any).fetchWantedItems).toHaveBeenCalledWith('cutoff', { pageSize: 1 });
-      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(mockRecords);
+      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(mockRecords, undefined);
     });
 
     it('should handle no missing items found', async () => {
@@ -184,7 +184,7 @@ describe('ArrClient metadata configuration', () => {
       await client.triggerMissingSearches(-1);
 
       expect((client as any).fetchWantedItems).toHaveBeenCalledWith('missing', undefined);
-      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(mockRecords);
+      expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(mockRecords, undefined);
     });
   });
 });
@@ -753,9 +753,9 @@ describe('ArrClient integration methods', () => {
       expect(mockTriggerItemSearch).toHaveBeenCalledTimes(3);
 
       // Verify it was called with the correct items
-      expect(mockTriggerItemSearch).toHaveBeenNthCalledWith(1, items[0]);
-      expect(mockTriggerItemSearch).toHaveBeenNthCalledWith(2, items[1]);
-      expect(mockTriggerItemSearch).toHaveBeenNthCalledWith(3, items[2]);
+      expect(mockTriggerItemSearch).toHaveBeenNthCalledWith(1, items[0], undefined);
+      expect(mockTriggerItemSearch).toHaveBeenNthCalledWith(2, items[1], undefined);
+      expect(mockTriggerItemSearch).toHaveBeenNthCalledWith(3, items[2], undefined);
 
       vi.useRealTimers();
     });

--- a/tests/arr-client.test.ts
+++ b/tests/arr-client.test.ts
@@ -109,14 +109,14 @@ describe('ArrClient metadata configuration', () => {
       vi.spyOn(client as any, 'fetchWantedItems').mockResolvedValue({ records: [] });
       vi.spyOn(client as any, 'triggerSearchesWithStagger').mockResolvedValue(undefined);
 
-      await expect(client.triggerMissingSearches(0)).resolves.toBeUndefined();
+      await expect(client.triggerMissingSearches(0)).resolves.toBe(0);
     });
 
     it('should execute triggerCutoffSearches without errors', async () => {
       vi.spyOn(client as any, 'fetchWantedItems').mockResolvedValue({ records: [] });
       vi.spyOn(client as any, 'triggerSearchesWithStagger').mockResolvedValue(undefined);
 
-      await expect(client.triggerCutoffSearches(0)).resolves.toBeUndefined();
+      await expect(client.triggerCutoffSearches(0)).resolves.toBe(0);
     });
 
     it('should handle missing items with batch limit', async () => {

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -47,12 +47,14 @@ class MockArrClient implements Partial<ArrClient> {
     // Mock implementation
   }
 
-  async triggerMissingSearches(limit?: number): Promise<void> {
+  async triggerMissingSearches(limit?: number): Promise<number> {
     this.triggerMissingSearchesCalls.push(limit ?? -999);
+    return 0;
   }
 
-  async triggerCutoffSearches(limit?: number): Promise<void> {
+  async triggerCutoffSearches(limit?: number): Promise<number> {
     this.triggerCutoffSearchesCalls.push(limit ?? -999);
+    return 0;
   }
 }
 


### PR DESCRIPTION
## Changes

This PR implements the remaining item from Issue #26: improved logging during media fetching operations.

### What's New

**1. Cycle Tracking with UUID**
- Each cycle now has a unique identifier for better traceability
- Cycle start and completion are logged with the same UUID

**2. Media Titles at INFO Level**
- Shows first 5 media titles in batch trigger logs
- Falls back to ID if title is unavailable
- Format: "Title1, Title2, ... and X more"

**3. Enhanced Statistics**
- Fetched item counts logged separately
- Trigger duration tracking (per batch)
- Cycle completion summary with:
  - Total items triggered across all instances
  - Total cycle duration
  - Per-instance breakdown (missing + cutoff counts)

**4. Structured Logging Improvements**
- All metrics included in structured log fields
- Better visibility without overwhelming output
- Debug level still has per-item details

### Example Output

```
[INFO] Starting indexer trigger cycle (cycleId=550e8400-e29b-41d4-a716-446655440000)
[INFO] Processing instance (instance=radarr-main, weight=2, missingBatch=50)
[INFO] Fetched 50 wanted movies (count=50, type=missing)
[INFO] Triggering searches for: The Matrix, Inception, Interstellar, Blade Runner 2049, Dune ... and 45 more (count=50, type=missing)
[INFO] Triggered 50 searches (count=50, type=missing, durationMs=15234)
[INFO] Cycle complete (cycleId=550e8400-e29b-41d4-a716-446655440000, totalTriggered=75, durationMs=45678, instances=[...])
```

### Tests

- ✅ All 165 tests pass
- Updated test expectations for new return types (trigger methods now return counts)
- Updated mocks to match new signatures

Closes #26