### PR TITLE
feat: implement retry_interval_days backoff filtering

### DIFF
--- a/src/clients/ArrClient.ts
+++ b/src/clients/ArrClient.ts
@@ -369,7 +369,9 @@ export class ArrClient {
       totalFiltered += pageItems.length - itemsToAdd.length;
 
       // Check termination conditions
-      const hasMorePages = pageItems.length === PAGE_SIZE;
+      const hasMorePages = response.totalRecords
+        ? currentPage * PAGE_SIZE < response.totalRecords
+        : pageItems.length === PAGE_SIZE;
       const hasEnoughItems = !unlimited && filteredItems.length >= targetCount;
 
       if (!hasMorePages || hasEnoughItems) {
@@ -412,7 +414,7 @@ export class ArrClient {
       );
     }
 
-    // Warn if partial batch (couldn't reach target)
+    // Log info if partial batch (couldn't reach target)
     if (!unlimited && targetCount > 0 && result.length < targetCount && result.length > 0) {
       this.logger.info(
         {

--- a/src/clients/ArrClient.ts
+++ b/src/clients/ArrClient.ts
@@ -274,6 +274,161 @@ export class ArrClient {
   }
 
   /**
+   * Check if an item should be included based on retry interval
+   *
+   * @param item - Media item to check
+   * @param retryIntervalDays - Retry interval in days
+   * @returns true if item should be included
+   */
+  private shouldIncludeItem(item: MediaItem, retryIntervalDays: number): boolean {
+    if (retryIntervalDays === 0) return true;
+
+    const lastSearchTime = item['lastSearchTime'];
+
+    // Include items never searched (null/undefined/missing)
+    if (!lastSearchTime) {
+      return true;
+    }
+
+    try {
+      const lastSearchDate = new Date(lastSearchTime as string).getTime();
+
+      // Invalid date parsing returns NaN
+      if (isNaN(lastSearchDate)) {
+        this.logger.debug(
+          { itemId: item.id, lastSearchTime },
+          'Invalid lastSearchTime format, including item'
+        );
+        return true; // Fail open
+      }
+
+      const retryThresholdMs = Date.now() - retryIntervalDays * 24 * 60 * 60 * 1000;
+
+      return lastSearchDate < retryThresholdMs;
+    } catch (error) {
+      // Date parsing error - fail open
+      this.logger.debug(
+        { itemId: item.id, lastSearchTime, error },
+        'Error parsing lastSearchTime, including item'
+      );
+      return true;
+    }
+  }
+
+  /**
+   * Fetch wanted items with optional retry interval filtering
+   * Uses pagination to avoid memory issues with large lists
+   *
+   * @param batchType - 'missing' or 'cutoff'
+   * @param targetCount - Number of items needed (-1 = unlimited)
+   * @param cycleId - Optional cycle ID for logging
+   * @returns Array of filtered items
+   */
+  private async fetchWantedItemsWithFiltering(
+    batchType: 'missing' | 'cutoff',
+    targetCount: number,
+    cycleId?: string
+  ): Promise<MediaItem[]> {
+    const PAGE_SIZE = 100;
+    const retryIntervalDays = this.settings.retry_interval_days;
+    const unlimited = targetCount === -1;
+
+    const filteredItems: MediaItem[] = [];
+    let currentPage = 1;
+    let totalFetched = 0;
+    let totalFiltered = 0;
+
+    while (true) {
+      // Fetch page
+      const response = await this.fetchWantedItems(batchType, {
+        page: currentPage,
+        pageSize: PAGE_SIZE,
+      });
+
+      const pageItems = response.records ?? [];
+      totalFetched += pageItems.length;
+
+      this.logger.debug(
+        {
+          page: currentPage,
+          pageSize: pageItems.length,
+          totalRecords: response.totalRecords,
+          type: batchType,
+          cycleId,
+        },
+        `Fetched page ${currentPage} with ${pageItems.length} items`
+      );
+
+      // Filter items if retry interval is enabled
+      const itemsToAdd =
+        retryIntervalDays > 0
+          ? pageItems.filter((item) => this.shouldIncludeItem(item, retryIntervalDays))
+          : pageItems;
+
+      filteredItems.push(...itemsToAdd);
+      totalFiltered += pageItems.length - itemsToAdd.length;
+
+      // Check termination conditions
+      const hasMorePages = pageItems.length === PAGE_SIZE;
+      const hasEnoughItems = !unlimited && filteredItems.length >= targetCount;
+
+      if (!hasMorePages || hasEnoughItems) {
+        break;
+      }
+
+      currentPage++;
+    }
+
+    // Trim to exact target count if needed
+    const result =
+      unlimited || filteredItems.length <= targetCount
+        ? filteredItems
+        : filteredItems.slice(0, targetCount);
+
+    // Log summary
+    if (retryIntervalDays > 0) {
+      this.logger.info(
+        {
+          fetched: totalFetched,
+          filtered: totalFiltered,
+          retained: result.length,
+          pages: currentPage,
+          type: batchType,
+          retryIntervalDays,
+          cycleId,
+        },
+        `Paged fetch complete: ${result.length} items retained after filtering (${totalFiltered} filtered out)`
+      );
+    } else {
+      this.logger.info(
+        {
+          fetched: totalFetched,
+          retained: result.length,
+          pages: currentPage,
+          type: batchType,
+          cycleId,
+        },
+        `Paged fetch complete: ${result.length} items fetched`
+      );
+    }
+
+    // Warn if partial batch (couldn't reach target)
+    if (!unlimited && targetCount > 0 && result.length < targetCount && result.length > 0) {
+      this.logger.info(
+        {
+          requested: targetCount,
+          found: result.length,
+          type: batchType,
+          cycleId,
+        },
+        `Partial batch: Only ${result.length} of ${targetCount} requested items found after filtering`
+      );
+    }
+
+    return result;
+  }
+
+  /**
    * Fetch items and trigger indexer searches (missing or cutoff)
    * Returns the number of searches triggered
    */
@@ -292,10 +447,10 @@ export class ArrClient {
       return 0;
     }
 
-    const params = batchSize > 0 ? { pageSize: batchSize } : undefined;
-    const wantedItems = await this.fetchWantedItems(batchType, params);
+    // Fetch items with pagination and optional retry interval filtering
+    const itemsToTrigger = await this.fetchWantedItemsWithFiltering(batchType, batchSize, cycleId);
 
-    if (!wantedItems.records || wantedItems.records.length === 0) {
+    if (itemsToTrigger.length === 0) {
       const message =
         batchType === 'cutoff'
           ? `No cutoff unmet ${this.metadata.mediaPlural} found`
@@ -304,19 +459,11 @@ export class ArrClient {
       return 0;
     }
 
-    const itemsToTrigger =
-      batchSize > 0 ? wantedItems.records.slice(0, batchSize) : wantedItems.records;
-
-    this.logger.info(
-      { count: itemsToTrigger.length, type: batchType, cycleId },
-      `Fetched ${itemsToTrigger.length} wanted ${this.metadata.mediaPlural}`
-    );
-
     const titleSample = formatTitleSample(itemsToTrigger, 5);
     const logMessage =
       batchType === 'cutoff'
-        ? `Triggering searches for: ${titleSample}`
-        : `Triggering searches for: ${titleSample}`;
+        ? `Triggering searches for cutoff unmet: ${titleSample}`
+        : `Triggering searches for missing: ${titleSample}`;
 
     this.logger.info({ count: itemsToTrigger.length, type: batchType, cycleId }, logMessage);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,14 +46,6 @@ export async function main() {
       'Configuration loaded'
     );
 
-    // Warn if retry_interval_days is configured but not implemented
-    if (config.global.retry_interval_days > 0) {
-      logger.warn(
-        { retry_interval_days: config.global.retry_interval_days },
-        'retry_interval_days is configured but not yet implemented - parameter will be ignored. See TODO.md for implementation requirements.'
-      );
-    }
-
     // Warn if random search order is configured (requires client-side filtering)
     if (config.global.search_order === 'random') {
       logger.warn(

--- a/tests/arr-client.test.ts
+++ b/tests/arr-client.test.ts
@@ -786,17 +786,24 @@ describe('ArrClient integration methods', () => {
   });
 
   describe('retry_interval_days filtering', () => {
-    // Helper to create timestamps relative to now
+    const FIXED_NOW = new Date('2024-01-15T12:00:00.000Z');
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FIXED_NOW);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Helper to create timestamps relative to now using fixed millisecond offsets
     function daysAgo(days: number): string {
-      const date = new Date();
-      date.setDate(date.getDate() - days);
-      return date.toISOString();
+      return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
     }
 
     function hoursAgo(hours: number): string {
-      const date = new Date();
-      date.setHours(date.getHours() - hours);
-      return date.toISOString();
+      return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
     }
 
     describe('shouldIncludeItem filtering logic', () => {
@@ -830,7 +837,7 @@ describe('ArrClient integration methods', () => {
         expect((client as any).shouldIncludeItem(item, 7)).toBe(false);
       });
 
-      it('should include items at exactly the retry interval boundary', () => {
+      it('should exclude items at exactly the retry interval boundary', () => {
         const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: daysAgo(7) };
         // At exactly 7 days, should be excluded (still within interval)
         expect((client as any).shouldIncludeItem(item, 7)).toBe(false);

--- a/tests/arr-client.test.ts
+++ b/tests/arr-client.test.ts
@@ -129,7 +129,11 @@ describe('ArrClient metadata configuration', () => {
 
       await client.triggerMissingSearches(2);
 
-      expect((client as any).fetchWantedItems).toHaveBeenCalledWith('missing', { pageSize: 2 });
+      // Now uses paged fetching with page=1, pageSize=100
+      expect((client as any).fetchWantedItems).toHaveBeenCalledWith('missing', {
+        page: 1,
+        pageSize: 100,
+      });
       expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(
         mockRecords,
         undefined
@@ -143,7 +147,11 @@ describe('ArrClient metadata configuration', () => {
 
       await client.triggerCutoffSearches(1);
 
-      expect((client as any).fetchWantedItems).toHaveBeenCalledWith('cutoff', { pageSize: 1 });
+      // Now uses paged fetching with page=1, pageSize=100
+      expect((client as any).fetchWantedItems).toHaveBeenCalledWith('cutoff', {
+        page: 1,
+        pageSize: 100,
+      });
       expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(
         mockRecords,
         undefined
@@ -175,8 +183,11 @@ describe('ArrClient metadata configuration', () => {
 
       await client.triggerCutoffSearches();
 
-      // Default upgrade_batch_size is 10 from createSettings
-      expect((client as any).fetchWantedItems).toHaveBeenCalledWith('cutoff', { pageSize: 10 });
+      // Now uses paged fetching with page=1, pageSize=100
+      expect((client as any).fetchWantedItems).toHaveBeenCalledWith('cutoff', {
+        page: 1,
+        pageSize: 100,
+      });
     });
 
     it('should handle unlimited batch size (-1)', async () => {
@@ -189,7 +200,11 @@ describe('ArrClient metadata configuration', () => {
 
       await client.triggerMissingSearches(-1);
 
-      expect((client as any).fetchWantedItems).toHaveBeenCalledWith('missing', undefined);
+      // Now uses paged fetching with page=1, pageSize=100
+      expect((client as any).fetchWantedItems).toHaveBeenCalledWith('missing', {
+        page: 1,
+        pageSize: 100,
+      });
       expect((client as any).triggerSearchesWithStagger).toHaveBeenCalledWith(
         mockRecords,
         undefined
@@ -767,6 +782,429 @@ describe('ArrClient integration methods', () => {
       expect(mockTriggerItemSearch).toHaveBeenNthCalledWith(3, items[2], undefined);
 
       vi.useRealTimers();
+    });
+  });
+
+  describe('retry_interval_days filtering', () => {
+    // Helper to create timestamps relative to now
+    function daysAgo(days: number): string {
+      const date = new Date();
+      date.setDate(date.getDate() - days);
+      return date.toISOString();
+    }
+
+    function hoursAgo(hours: number): string {
+      const date = new Date();
+      date.setHours(date.getHours() - hours);
+      return date.toISOString();
+    }
+
+    describe('shouldIncludeItem filtering logic', () => {
+      it('should include items never searched (no lastSearchTime)', () => {
+        const item: MediaItem = { id: 1, title: 'Movie 1' };
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(true);
+      });
+
+      it('should include items with undefined lastSearchTime', () => {
+        const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: undefined };
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(true);
+      });
+
+      it('should include items with null lastSearchTime', () => {
+        const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: null };
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(true);
+      });
+
+      it('should include items searched before retry interval', () => {
+        const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: daysAgo(10) };
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(true);
+      });
+
+      it('should exclude items searched within retry interval', () => {
+        const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: daysAgo(3) };
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(false);
+      });
+
+      it('should exclude items searched very recently', () => {
+        const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: hoursAgo(1) };
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(false);
+      });
+
+      it('should include items at exactly the retry interval boundary', () => {
+        const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: daysAgo(7) };
+        // At exactly 7 days, should be excluded (still within interval)
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(false);
+      });
+
+      it('should include items just beyond the retry interval', () => {
+        // 7 days + 1 hour should be included
+        const date = new Date();
+        date.setDate(date.getDate() - 7);
+        date.setHours(date.getHours() - 1);
+        const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: date.toISOString() };
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(true);
+      });
+
+      it('should include items with invalid lastSearchTime (fail open)', () => {
+        const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: 'invalid-date' };
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(true);
+      });
+
+      it('should include items with malformed date string', () => {
+        const item: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: '2026-99-99' };
+        expect((client as any).shouldIncludeItem(item, 7)).toBe(true);
+      });
+
+      it('should include all items when retry_interval_days = 0', () => {
+        const recentItem: MediaItem = { id: 1, title: 'Movie 1', lastSearchTime: hoursAgo(1) };
+        const oldItem: MediaItem = { id: 2, title: 'Movie 2', lastSearchTime: daysAgo(100) };
+        const neverSearched: MediaItem = { id: 3, title: 'Movie 3' };
+
+        expect((client as any).shouldIncludeItem(recentItem, 0)).toBe(true);
+        expect((client as any).shouldIncludeItem(oldItem, 0)).toBe(true);
+        expect((client as any).shouldIncludeItem(neverSearched, 0)).toBe(true);
+      });
+
+      it('should handle different retry interval values', () => {
+        const item30Days: MediaItem = { id: 1, lastSearchTime: daysAgo(35) };
+        const item7Days: MediaItem = { id: 2, lastSearchTime: daysAgo(10) };
+        const item1Day: MediaItem = { id: 3, lastSearchTime: hoursAgo(12) };
+
+        // 30 days interval
+        expect((client as any).shouldIncludeItem(item30Days, 30)).toBe(true);
+        expect((client as any).shouldIncludeItem(item7Days, 30)).toBe(false);
+
+        // 7 days interval
+        expect((client as any).shouldIncludeItem(item7Days, 7)).toBe(true);
+        expect((client as any).shouldIncludeItem(item1Day, 7)).toBe(false);
+
+        // 1 day interval
+        expect((client as any).shouldIncludeItem(item1Day, 1)).toBe(false);
+        expect((client as any).shouldIncludeItem(item7Days, 1)).toBe(true);
+      });
+    });
+
+    describe('fetchWantedItemsWithFiltering pagination', () => {
+      beforeEach(() => {
+        mockHttpGet.mockReset();
+      });
+
+      it('should fetch single page when enough items found', async () => {
+        const items = Array.from({ length: 100 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+          lastSearchTime: daysAgo(10), // All eligible
+        }));
+
+        mockHttpGet.mockResolvedValueOnce({ records: items, pageSize: 100 });
+
+        const result = await (client as any).fetchWantedItemsWithFiltering(
+          'missing',
+          50,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(50);
+        expect(mockHttpGet).toHaveBeenCalledTimes(1);
+        expect(mockHttpGet).toHaveBeenCalledWith(
+          '/api/v3/wanted/missing',
+          expect.objectContaining({
+            page: 1,
+            pageSize: 100,
+          })
+        );
+      });
+
+      it('should fetch multiple pages until batch size reached', async () => {
+        // Create client with retry_interval_days > 0 to enable filtering
+        const settings = createSettings('last_searched_ascending');
+        settings.retry_interval_days = 7;
+        const filterClient = new ArrClient('radarr', 'test', 'http://localhost', 'key', settings);
+        (filterClient as any).http = { get: mockHttpGet };
+
+        // Page 1: 100 items, all recent (filtered out)
+        const page1Items = Array.from({ length: 100 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+          lastSearchTime: daysAgo(2), // Too recent
+        }));
+
+        // Page 2: 50 items, first 20 eligible
+        const page2Items = Array.from({ length: 50 }, (_, i) => ({
+          id: i + 101,
+          title: `Movie ${i + 101}`,
+          lastSearchTime: i < 20 ? daysAgo(10) : daysAgo(2),
+        }));
+
+        mockHttpGet
+          .mockResolvedValueOnce({ records: page1Items, pageSize: 100 })
+          .mockResolvedValueOnce({ records: page2Items, pageSize: 50 });
+
+        const result = await (filterClient as any).fetchWantedItemsWithFiltering(
+          'missing',
+          20,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(20);
+        expect(mockHttpGet).toHaveBeenCalledTimes(2);
+        expect(mockHttpGet).toHaveBeenNthCalledWith(
+          1,
+          '/api/v3/wanted/missing',
+          expect.objectContaining({ page: 1 })
+        );
+        expect(mockHttpGet).toHaveBeenNthCalledWith(
+          2,
+          '/api/v3/wanted/missing',
+          expect.objectContaining({ page: 2 })
+        );
+      });
+
+      it('should stop early when enough filtered items found', async () => {
+        const page1Items = Array.from({ length: 100 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+          lastSearchTime: daysAgo(10), // All eligible
+        }));
+
+        mockHttpGet.mockResolvedValueOnce({ records: page1Items, pageSize: 100 });
+
+        const result = await (client as any).fetchWantedItemsWithFiltering(
+          'missing',
+          50,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(50);
+        expect(mockHttpGet).toHaveBeenCalledTimes(1); // Only fetched 1 page, stopped early
+      });
+
+      it('should fetch all pages when unlimited batch size (-1)', async () => {
+        const page1Items = Array.from({ length: 100 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+          lastSearchTime: daysAgo(10),
+        }));
+
+        const page2Items = Array.from({ length: 30 }, (_, i) => ({
+          id: i + 101,
+          title: `Movie ${i + 101}`,
+          lastSearchTime: daysAgo(10),
+        }));
+
+        mockHttpGet
+          .mockResolvedValueOnce({ records: page1Items, pageSize: 100 })
+          .mockResolvedValueOnce({ records: page2Items, pageSize: 30 });
+
+        const result = await (client as any).fetchWantedItemsWithFiltering(
+          'missing',
+          -1,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(130);
+        expect(mockHttpGet).toHaveBeenCalledTimes(2);
+      });
+
+      it('should return partial batch when not enough items available', async () => {
+        const items = Array.from({ length: 10 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+          lastSearchTime: daysAgo(10),
+        }));
+
+        mockHttpGet.mockResolvedValueOnce({ records: items, pageSize: 10 });
+
+        const result = await (client as any).fetchWantedItemsWithFiltering(
+          'missing',
+          50,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(10); // Only 10 available, not 50
+      });
+
+      it('should bypass filtering when retry_interval_days = 0', async () => {
+        const items = Array.from({ length: 50 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+          lastSearchTime: hoursAgo(1), // Very recent
+        }));
+
+        mockHttpGet.mockResolvedValueOnce({ records: items, pageSize: 50 });
+
+        const settings = createSettings('last_searched_ascending');
+        settings.retry_interval_days = 0; // Disabled
+        const noFilterClient = new ArrClient('radarr', 'test', 'http://localhost', 'key', settings);
+        (noFilterClient as any).http = { get: mockHttpGet };
+
+        const result = await (noFilterClient as any).fetchWantedItemsWithFiltering(
+          'missing',
+          50,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(50); // All included despite recent timestamps
+      });
+
+      it('should handle empty response', async () => {
+        mockHttpGet.mockResolvedValueOnce({ records: [] });
+
+        const result = await (client as any).fetchWantedItemsWithFiltering(
+          'missing',
+          20,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(0);
+        expect(mockHttpGet).toHaveBeenCalledTimes(1);
+      });
+
+      it('should handle mixed eligible and ineligible items', async () => {
+        // Create client with retry_interval_days > 0 to enable filtering
+        const settings = createSettings('last_searched_ascending');
+        settings.retry_interval_days = 7;
+        const filterClient = new ArrClient('radarr', 'test', 'http://localhost', 'key', settings);
+        (filterClient as any).http = { get: mockHttpGet };
+
+        const items = Array.from({ length: 20 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+          // Every other item is eligible
+          lastSearchTime: i % 2 === 0 ? daysAgo(10) : daysAgo(2),
+        }));
+
+        mockHttpGet.mockResolvedValueOnce({ records: items, pageSize: 20 });
+
+        const result = await (filterClient as any).fetchWantedItemsWithFiltering(
+          'missing',
+          20,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(10); // Half are eligible
+      });
+
+      it('should continue fetching when first pages have no eligible items', async () => {
+        // Create client with retry_interval_days > 0 to enable filtering
+        const settings = createSettings('last_searched_ascending');
+        settings.retry_interval_days = 7;
+        const filterClient = new ArrClient('radarr', 'test', 'http://localhost', 'key', settings);
+        (filterClient as any).http = { get: mockHttpGet };
+
+        const page1Items = Array.from({ length: 100 }, (_, i) => ({
+          id: i + 1,
+          lastSearchTime: hoursAgo(1), // All recent
+        }));
+
+        const page2Items = Array.from({ length: 100 }, (_, i) => ({
+          id: i + 101,
+          lastSearchTime: hoursAgo(1), // All recent
+        }));
+
+        const page3Items = Array.from({ length: 50 }, (_, i) => ({
+          id: i + 201,
+          lastSearchTime: daysAgo(10), // All eligible
+        }));
+
+        mockHttpGet
+          .mockResolvedValueOnce({ records: page1Items, pageSize: 100 })
+          .mockResolvedValueOnce({ records: page2Items, pageSize: 100 })
+          .mockResolvedValueOnce({ records: page3Items, pageSize: 50 });
+
+        const result = await (filterClient as any).fetchWantedItemsWithFiltering(
+          'missing',
+          20,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(20);
+        expect(mockHttpGet).toHaveBeenCalledTimes(3);
+      });
+
+      it('should work with cutoff batch type', async () => {
+        const items = Array.from({ length: 30 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+          lastSearchTime: daysAgo(10),
+        }));
+
+        mockHttpGet.mockResolvedValueOnce({ records: items, pageSize: 30 });
+
+        const result = await (client as any).fetchWantedItemsWithFiltering(
+          'cutoff',
+          20,
+          'test-cycle'
+        );
+
+        expect(result).toHaveLength(20);
+        expect(mockHttpGet).toHaveBeenCalledWith(
+          '/api/v3/wanted/cutoff',
+          expect.objectContaining({
+            page: 1,
+            pageSize: 100,
+          })
+        );
+      });
+    });
+
+    describe('processBatch integration with filtering', () => {
+      beforeEach(() => {
+        mockHttpGet.mockReset();
+        mockHttpPost.mockReset();
+      });
+
+      it('should use paged fetching with filtering when retry_interval_days > 0', async () => {
+        const settings = createSettings('last_searched_ascending');
+        settings.retry_interval_days = 7;
+        const filterClient = new ArrClient('radarr', 'test', 'http://localhost', 'key', settings);
+        (filterClient as any).http = { get: mockHttpGet, post: mockHttpPost };
+
+        const items = Array.from({ length: 20 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+          lastSearchTime: daysAgo(10),
+        }));
+
+        mockHttpGet.mockResolvedValue({ records: items, pageSize: 20 });
+        mockHttpPost.mockResolvedValue({ id: 123, name: 'MoviesSearch' });
+
+        await filterClient.triggerMissingSearches(20, 'test-cycle');
+
+        expect(mockHttpGet).toHaveBeenCalledWith(
+          '/api/v3/wanted/missing',
+          expect.objectContaining({
+            page: 1,
+            pageSize: 100,
+          })
+        );
+      });
+
+      it('should use paged fetching even when retry_interval_days = 0', async () => {
+        const settings = createSettings('last_searched_ascending');
+        settings.retry_interval_days = 0;
+        const noFilterClient = new ArrClient('radarr', 'test', 'http://localhost', 'key', settings);
+        (noFilterClient as any).http = { get: mockHttpGet, post: mockHttpPost };
+
+        const items = Array.from({ length: 20 }, (_, i) => ({
+          id: i + 1,
+          title: `Movie ${i + 1}`,
+        }));
+
+        mockHttpGet.mockResolvedValue({ records: items, pageSize: 20 });
+        mockHttpPost.mockResolvedValue({ id: 123, name: 'MoviesSearch' });
+
+        await noFilterClient.triggerMissingSearches(20, 'test-cycle');
+
+        // Should still use pagination API
+        expect(mockHttpGet).toHaveBeenCalledWith(
+          '/api/v3/wanted/missing',
+          expect.objectContaining({
+            page: 1,
+            pageSize: 100,
+          })
+        );
+      });
     });
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -70,39 +70,6 @@ describe('Main Application', () => {
   });
 
   describe('warnings', () => {
-    it('should warn when retry_interval_days is configured', async () => {
-      const config: Config = {
-        global: {
-          interval: 3600,
-          missing_batch_size: 20,
-          upgrade_batch_size: 10,
-          stagger_interval_seconds: 30,
-          search_order: 'last_searched_ascending',
-          retry_interval_days: 7,
-          dry_run: false,
-        },
-        instances: {
-          radarr: {
-            type: 'radarr',
-            host: 'http://radarr:7878',
-            api_key: 'test-key',
-            enabled: true,
-            weight: 1.0,
-          },
-        },
-      };
-
-      mockLoadConfig.mockReturnValue(config);
-
-      const { main } = await import('../src/index.js');
-      await main();
-
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        { retry_interval_days: 7 },
-        expect.stringContaining('retry_interval_days is configured but not yet implemented')
-      );
-    });
-
     it('should warn when random search order is configured', async () => {
       const config: Config = {
         global: {
@@ -133,39 +100,6 @@ describe('Main Application', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ search_order: 'random' }),
         expect.stringContaining('random search order is configured but not yet fully implemented')
-      );
-    });
-
-    it('should not warn when retry_interval_days is 0', async () => {
-      const config: Config = {
-        global: {
-          interval: 3600,
-          missing_batch_size: 20,
-          upgrade_batch_size: 10,
-          stagger_interval_seconds: 30,
-          search_order: 'last_searched_ascending',
-          retry_interval_days: 0,
-          dry_run: false,
-        },
-        instances: {
-          radarr: {
-            type: 'radarr',
-            host: 'http://radarr:7878',
-            api_key: 'test-key',
-            enabled: true,
-            weight: 1.0,
-          },
-        },
-      };
-
-      mockLoadConfig.mockReturnValue(config);
-
-      const { main } = await import('../src/index.js');
-      await main();
-
-      expect(mockLogger.warn).not.toHaveBeenCalledWith(
-        expect.objectContaining({ retry_interval_days: expect.any(Number) }),
-        expect.stringContaining('retry_interval_days')
       );
     });
   });


### PR DESCRIPTION
## Description

Implements client-side filtering for wanted items based on the `retry_interval_days` configuration parameter.

## Changes

### Core Implementation
- **Paged Fetching**: Fetches items in pages of 100 to avoid memory issues with large wanted lists
- **Client-Side Filtering**: Filters items based on `lastSearchTime` field
- **Early Termination**: Stops fetching additional pages once enough filtered items are collected
- **Fail-Open Approach**: Items with missing or invalid `lastSearchTime` are included

### Key Features
- ✅ Always uses paged fetching (even when filtering disabled)
- ✅ Fixed page size: 100 items per page
- ✅ Handles unlimited batch size (-1) by fetching all pages
- ✅ Proper handling of items never searched (no lastSearchTime)
- ✅ UTC timestamp comparisons for timezone consistency
- ✅ Comprehensive debug and info logging
- ✅ Partial batch warnings when insufficient eligible items

### Technical Details
- **New Methods**:
  - `shouldIncludeItem()`: Helper to check if item is eligible based on retry interval
  - `fetchWantedItemsWithFiltering()`: Paged fetching with optional filtering
- **Modified Methods**:
  - `processBatch()`: Simplified to use new paged fetching
- **Bonus Fix**: Different log messages for missing vs cutoff unmet searches

### Testing
- Added 23 test cases covering:
  - Filtering logic (boundary conditions, invalid dates, etc.)
  - Pagination behavior (single/multiple pages, early termination)
  - Integration with processBatch

Closes #8