### PR TITLE
fix: TS issue in Orchestrator test

### DIFF
--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -25,8 +25,8 @@ vi.mock('../src/logger.js', () => ({
 
 // Mock ArrClient
 class MockArrClient implements Partial<ArrClient> {
-  private name: string;
-  private weight: number;
+  readonly name: string;
+  readonly weight: number;
   public triggerMissingSearchesCalls: number[] = [];
   public triggerCutoffSearchesCalls: number[] = [];
 


### PR DESCRIPTION
## Description

Fixes TS issue in Orchestrator test:
```
Class 'MockArrClient' incorrectly implements interface 'Partial<ArrClient>'.
Property 'name' is private in type 'MockArrClient' but not in type 'Partial<ArrClient>'.
```
